### PR TITLE
arp_resolver: match case literal width to counter signal width

### DIFF
--- a/hdl/arp/arp_resolver.vhd
+++ b/hdl/arp/arp_resolver.vhd
@@ -100,7 +100,7 @@ process(clk)
     begin
         if rising_edge(clk) then
             case counter is
-                when  "000" =>  if ch0_lookup_request = '1' then
+                when  "00" =>  if ch0_lookup_request = '1' then
                                    arp_lookup_ip   <= ch0_lookup_ip;
                                    ch0_in_progress <= '1';
                                 else
@@ -119,7 +119,7 @@ process(clk)
                                 end if; 
 
 
-                when  "001" =>  if ch1_lookup_request = '1' then
+                when  "01" =>  if ch1_lookup_request = '1' then
                                    arp_lookup_ip   <= ch1_lookup_ip;
                                    ch1_in_progress <= '1';
                                 else
@@ -137,7 +137,7 @@ process(clk)
                                     arp_request <= '0';
                                 end if; 
 
-                when  "010" =>  if ch2_lookup_request = '1' then
+                when  "10" =>  if ch2_lookup_request = '1' then
                                    arp_lookup_ip   <= ch2_lookup_ip;
                                    ch2_in_progress <= '1';
                                 else


### PR DESCRIPTION
## Summary

In `hdl/arp/arp_resolver.vhd`, the case statement in the main process branches against `unsigned(1 downto 0)` (a 2-bit signal, declared at line 84) but the branch literals are 3 bits wide (`"000"`, `"001"`, `"010"`). Strict simulators (GHDL, NVC) reject this:

```
hdl/arp/arp_resolver.vhd:103:23:error: string length does not match
that of anonymous integer subtype defined at hdl/arp/arp_resolver.vhd:84:31
hdl/arp/arp_resolver.vhd:103:23:error: incorrect length for the choice value
```

Vivado / XST appear to accept it historically (likely silently truncating the leading zero), which is presumably why the bug hasn't surfaced in synthesis runs.

This PR shrinks the literals to 2 bits to match the signal type. Run-time behaviour is unchanged.

## Test

Before:
```
$ ghdl -a --std=08 hdl/arp/arp_resolver.vhd
... 6 errors related to case literal width
```

After:
```
$ ghdl -a --std=08 hdl/arp/arp_resolver.vhd
(case-literal errors gone; the remaining errors in this file are
 unrelated missing-declaration issues for arp_lookup_mac,
 arp_lookup_valid, arp_request, etc. — pre-existing and outside
 the scope of this PR.)
```

## Note

This patch was identified while exercising the project through a third-party VHDL → WebAssembly pipeline. The diagnosis and minimal fix were AI-assisted (large-language-model code review) and verified manually before submission.
